### PR TITLE
SC-14628 Allow setting preferCurrentTab for screen sharing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -121,6 +121,7 @@ declare module JanusStatic {
       failIfNoAudio?: boolean;
       failIfNoVideo?: boolean;
       screenshareFrameRate?: number;
+      screensharePreferCurrentTab?: boolean;
     };
     trickle?: boolean;
     stream?: any;

--- a/index.d.ts
+++ b/index.d.ts
@@ -116,7 +116,7 @@ declare module JanusStatic {
       audio?: any;
       videoSend?: boolean;
       videoRecv?: boolean;
-      video?: any;
+      video?: 'screen' | 'window' | 'desktop';
       data?: boolean;
       failIfNoAudio?: boolean;
       failIfNoVideo?: boolean;

--- a/lib/janus.nojquery.js
+++ b/lib/janus.nojquery.js
@@ -249,9 +249,12 @@ Janus.mediaToTracks = function(media) {
 						// Change the type to 'screen'
 						track.type = 'screen';
 						track.capture = { video: {} };
+						track.screenshare = {};
 						// Check if there's constraints
 						if(media.screenshareFrameRate)
 							track.capture.frameRate = media.screenshareFrameRate;
+						if (media.screensharePreferCurrentTab)
+							track.screenshare.preferCurrentTab = true;
 						if(media.screenshareHeight)
 							track.capture.height = media.screenshareHeight;
 						if(media.screenshareWidth)
@@ -334,6 +337,7 @@ Janus.trackConstraints = function(track) {
 	} else if(track.type === 'screen') {
 		// Use the provided capture object as video constraint
 		constraints.video = track.capture;
+		constraints.preferCurrentTab = track.screenshare?.preferCurrentTab;
 	}
 	return constraints;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jemmic/janus-client",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR allows setting the `preferCurrentTab` property for screen sharing, using a custom `screensharePreferCurrentTab` property passed in the Janus offer.

Also, it improves the typing of the `video` property in the same offer method.