### PR TITLE
SC-19605 Remove fallback to google stun server

### DIFF
--- a/lib/janus.nojquery.js
+++ b/lib/janus.nojquery.js
@@ -597,7 +597,7 @@ function Janus(gatewayCallbacks) {
 			Janus.log("Using REST API to contact Janus: " + server);
 		}
 	}
-	let iceServers = gatewayCallbacks.iceServers || [{urls: "stun:stun.l.google.com:19302"}];
+	let iceServers = gatewayCallbacks.iceServers;
 	let iceTransportPolicy = gatewayCallbacks.iceTransportPolicy;
 	let bundlePolicy = gatewayCallbacks.bundlePolicy;
 	// Whether we should enable the withCredentials flag for XHR requests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jemmic/janus-client",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR removes the fallback to the Google's STUN server in the case of no ICE servers are being set in our Secuchat configuration.

### Related PR's

- https://github.com/jemmic/secuchat/pull/4725